### PR TITLE
Preserve chat history when sending multiple prompts

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -34,7 +34,7 @@ export async function POST(request: Request) {
     resolution,
   } = await request.json();
 
-  const apiKey = process.env.E2B_API_KEY!;
+  const apiKey = process.env.E2B_API_KEY;
   const openaiApiKey = process.env.OPENAI_API_KEY;
 
   if (!apiKey) {

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "@ai-sdk/ui-utils": "1.1.10",
         "@ai-sdk/xai": "1.1.10",
         "@anthropic-ai/sdk": "^0.33.1",
-        "@e2b/desktop": "^1.4.0",
+        "@e2b/desktop": "^1.6.0",
         "@gradio/client": "^1.10.0",
         "@phosphor-icons/react": "^2.1.7",
         "@radix-ui/react-icons": "^1.3.2",
@@ -95,7 +95,7 @@
 
     "@connectrpc/connect-web": ["@connectrpc/connect-web@2.0.0-rc.3", "", { "peerDependencies": { "@bufbuild/protobuf": "^2.2.0", "@connectrpc/connect": "2.0.0-rc.3" } }, "sha512-w88P8Lsn5CCsA7MFRl2e6oLY4J/5toiNtJns/YJrlyQaWOy3RO8pDgkz+iIkG98RPMhj2thuBvsd3Cn4DKKCkw=="],
 
-    "@e2b/desktop": ["@e2b/desktop@1.4.0", "", { "dependencies": { "e2b": "^1.0.7" } }, "sha512-LYJocZLNvfdbDth8fBmCsTjJRt1QMJldr5YzAVeXStSq5c7/mHtZrDvgXUQNVWQd2XD2RGTvb+5md/7fColCTQ=="],
+    "@e2b/desktop": ["@e2b/desktop@1.6.0", "", { "dependencies": { "e2b": "^1.0.7" } }, "sha512-FuEL4e+Q2djgHewKq3lpuc0xaIogPWiFvif3Mj7vnkR2OulKDgbS19K9TJZYvTHRK7mt5BU6i2PMbukq6BVcQg=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.3.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw=="],
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@ai-sdk/ui-utils": "1.1.10",
     "@ai-sdk/xai": "1.1.10",
     "@anthropic-ai/sdk": "^0.33.1",
-    "@e2b/desktop": "^1.4.0",
+    "@e2b/desktop": "^1.6.0",
     "@gradio/client": "^1.10.0",
     "@phosphor-icons/react": "^2.1.7",
     "@radix-ui/react-icons": "^1.3.2",

--- a/types/api.ts
+++ b/types/api.ts
@@ -188,25 +188,7 @@ export async function executeAction(
       break;
     }
     case "keypress": {
-      // Key mapping from CUA to E2B format
-      const cua_e2b_key_mapping: Record<string, string> = {
-        ENTER: "Return",
-        LEFT: "Left",
-        RIGHT: "Right",
-        UP: "Up",
-        DOWN: "Down",
-        ESC: "Escape",
-        SPACE: "space",
-        BACKSPACE: "BackSpace",
-        TAB: "Tab",
-      };
-
-      // Handle multiple keys if needed
-      for (const key of action.keys) {
-        // Convert key if it exists in the mapping, otherwise use as is
-        const mappedKey = cua_e2b_key_mapping[key] || key;
-        await desktop.press(mappedKey);
-      }
+      await desktop.press(action.keys);
       break;
     }
     case "move": {


### PR DESCRIPTION
Although the message history was sent to the http function, it was not used in the openai sdk call. This is fixed with this pr. Also `@e2b/desktop` got upgraded to the latest version which doesn't require keymapping anymore in this repo.