### PR TITLE
feat: add Google Tag Manager (NEXT_PUBLIC_GTM_ID)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 E2B_API_KEY=your_e2b_api_key
 OPENAI_API_KEY=your_openai_api_key
+# Google Tag Manager container ID (set in the deploy environment)
+NEXT_PUBLIC_GTM_ID=GTM-XXXXXXX

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { Providers } from "../components/providers";
 import { IBM_Plex_Sans, IBM_Plex_Mono } from "next/font/google";
 import { ChatProvider } from "@/lib/chat-context";
 import { Analytics } from "@vercel/analytics/react";
+import { GoogleTagManager } from "@next/third-parties/google";
 
 const ibmPlexSans = IBM_Plex_Sans({
   subsets: ["latin"],
@@ -42,6 +43,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
+      {process.env.NEXT_PUBLIC_GTM_ID && (
+        <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID} />
+      )}
       <body
         className={`${ibmPlexSans.variable} ${ibmPlexMono.variable}`}
         suppressHydrationWarning

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@ai-sdk/xai": "1.1.10",
         "@e2b/desktop": "^1.8.1",
         "@gradio/client": "^1.10.0",
+        "@next/third-parties": "^15.5.20",
         "@phosphor-icons/react": "^2.1.7",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-scroll-area": "^1.2.3",
@@ -1570,6 +1571,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-15.5.20.tgz",
+      "integrity": "sha512-oy3ZObanGBGDHSbfxsf7fIqPe9fzt+M890pA+hZKr46w1jDl+YFlU2evPKb+j5+2TyJsRfHzeCz0lUiyPvNyGg==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -9922,6 +9936,12 @@
       "resolved": "https://registry.npmjs.org/textlinestream/-/textlinestream-1.1.1.tgz",
       "integrity": "sha512-iBHbi7BQxrFmwZUQJsT0SjNzlLLsXhvW/kg7EyOMVMBIrlnj/qYofwo1LVLZi+3GbUEo96Iu2eqToI2+lZoAEQ==",
       "license": "MIT"
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/thread-stream": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@ai-sdk/xai": "1.1.10",
     "@e2b/desktop": "^1.8.1",
     "@gradio/client": "^1.10.0",
+    "@next/third-parties": "^15.5.20",
     "@phosphor-icons/react": "^2.1.7",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-scroll-area": "^1.2.3",


### PR DESCRIPTION
Adds Google Tag Manager to the demo app, loaded via `@next/third-parties/google` and gated on `NEXT_PUBLIC_GTM_ID` so it only loads when the container ID is set (no-op locally / in forks).

**Deploy step:** set `NEXT_PUBLIC_GTM_ID=<shared GTM container id>` in the Vercel project env, then redeploy. Coexists with the existing Vercel Analytics.